### PR TITLE
feat(security): implement Spring Security config with JWT authentication filter and JpaUserDetailsService

### DIFF
--- a/src/main/java/com/backup_manager/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/backup_manager/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,108 @@
+package com.backup_manager.infrastructure.config;
+
+import com.backup_manager.infrastructure.security.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final UserDetailsService uds;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter, UserDetailsService uds) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.uds = uds;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider(uds);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authManager(AuthenticationConfiguration config) {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5176",
+                "http://localhost:3000"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Content-Type", "Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) {
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> {
+                })
+                .headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+
+                        .requestMatchers("/auth/login").permitAll()
+
+                        .requestMatchers("/h2-console/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml").permitAll()
+
+
+                        .requestMatchers("/api/backup/progress").permitAll()
+
+                        .requestMatchers("/api/backup/history").hasAnyAuthority("ROLE_ADMIN", "ROLE_SUPPORT")
+                        .requestMatchers("/api/backup/start").hasAnyAuthority("ROLE_ADMIN", "ROLE_SUPPORT")
+                        .requestMatchers("/api/logs/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_SUPPORT")
+
+                        .anyRequest().authenticated()
+                )
+
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/backup_manager/infrastructure/security/JpaUserDetailsService.java
+++ b/src/main/java/com/backup_manager/infrastructure/security/JpaUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.backup_manager.infrastructure.security;
+
+import com.backup_manager.domain.model.AppUser;
+import com.backup_manager.infrastructure.persistence.AppUserRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JpaUserDetailsService implements UserDetailsService {
+
+    private final AppUserRepository repository;
+
+    public JpaUserDetailsService(AppUserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        AppUser user = repository.finByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+
+        return User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .roles(user.getRole().replace("ROLE_", "")) // evita duplicação
+                .build();
+    }
+}

--- a/src/main/java/com/backup_manager/infrastructure/security/JwtAuthFilter.java
+++ b/src/main/java/com/backup_manager/infrastructure/security/JwtAuthFilter.java
@@ -1,0 +1,68 @@
+package com.backup_manager.infrastructure.security;
+
+import io.jsonwebtoken.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthFilter(JwtTokenService jwtTokenService, UserDetailsService userDetailsService) {
+        this.jwtTokenService = jwtTokenService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException, java.io.IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+        String username = jwtTokenService.getUsername(token);
+
+        try {
+            if (jwtTokenService.isValid(token) && username != null &&
+                    SecurityContextHolder.getContext().getAuthentication() == null) {
+
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        } catch (Exception e) {
+            // 🔹 Qualquer exceção de parsing → também 401
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
**What was done:**
- Configured full Spring Security in `SecurityConfig`:
  - Stateless session management (no cookies/sessions)
  - BCrypt password encoder
  - Custom `JwtAuthFilter` added before `UsernamePasswordAuthenticationFilter`
  - Defined public endpoints (login, Swagger UI, etc.) and protected all others
  - Disabled CSRF (appropriate for stateless JWT APIs)
- Implemented `JwtAuthFilter`:
  - Extracts JWT from `Authorization: Bearer` header
  - Validates token signature, expiration, and claims using `JwtTokenService`
  - Sets authenticated user in `SecurityContextHolder` if valid
  - Handles invalid/expired/missing tokens with 401 responses
- Created `JpaUserDetailsService`:
  - Loads user by username from database using `AppUserRepository`
  - Maps `AppUser` to Spring Security `UserDetails` (with authorities/roles)
  - Throws `UsernameNotFoundException` when user doesn't exist

**Why this change:**
This is the central piece of secure authentication for the API. It enables:
- Stateless JWT-based auth
- Database-backed users
- Protection of sensitive endpoints (backup operations, logs, etc.)
- Clean separation of concerns between token handling and user loading

**Dependencies:**
- spring-boot-starter-security
- jjwt-api, jjwt-impl, jjwt-jackson (for token handling)
