### PR TITLE
feat: implementar fluxo de restauracao com validacoes e notificacoes

### DIFF
--- a/src/main/java/com/backup_manager/application/controller/RestoreController.java
+++ b/src/main/java/com/backup_manager/application/controller/RestoreController.java
@@ -1,4 +1,227 @@
 package com.backup_manager.application.controller;
 
+import com.backup_manager.application.dto.FileTreeDTO;
+import com.backup_manager.application.dto.RestoreRequest;
+import com.backup_manager.application.dto.SelectiveRestoreRequest;
+import com.backup_manager.application.service.RestoreService;
+import com.backup_manager.domain.model.RestoreTask;
+import com.backup_manager.infrastructure.persistence.RestoreRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api")
 public class RestoreController {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestoreController.class);
+
+    private final RestoreService restoreService;
+    private final RestoreRepository restoreRepository;
+
+    public RestoreController(RestoreService restoreService, RestoreRepository restoreRepository) {
+        this.restoreService = restoreService;
+        this.restoreRepository = restoreRepository;
+    }
+
+    @GetMapping("/backup/{id}/restore/preview")
+    public ResponseEntity<?> previewBackupFiles(@PathVariable Long id) {
+        try {
+            logger.info("Preview solicitado para backup ID={}", id);
+            FileTreeDTO tree = restoreService.previewFiles(id);
+            return ResponseEntity.ok(tree);
+
+        } catch (IllegalArgumentException e) {
+            logger.warn("Backup não encontrado: {}", id);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (IllegalStateException e) {
+            logger.warn("Backup inválido: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (Exception e) {
+            logger.error("Erro ao gerar preview: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao gerar preview: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/backup/{id}/restore")
+    public ResponseEntity<?> startFullRestore(@PathVariable Long id,
+                                              @RequestBody RestoreRequest request) {
+        try {
+            logger.info("Restauração completa solicitada: backupId={}, target={}",
+                    id, request.getTargetPath());
+
+            Long taskId = restoreService.startFullRestore(id, request);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("taskId", taskId);
+            response.put("status", "EM_ANDAMENTO");
+            response.put("message", "Restauração iniciada com sucesso");
+
+            return ResponseEntity.ok(response);
+
+        } catch (SecurityException e) {
+            logger.warn("Bloqueio de segurança: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            logger.warn("Erro de validação: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (Exception e) {
+            logger.error("Erro ao iniciar restauração: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao iniciar restauração: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/backup/{id}/restore/selective")
+    public ResponseEntity<?> startSelectiveRestore(@PathVariable Long id,
+                                                   @RequestBody SelectiveRestoreRequest request) {
+        try {
+            int selectedFilesCount = request.getSelectedFiles() != null ? request.getSelectedFiles().size() : 0;
+            logger.info("Restauração seletiva solicitada: backupId={}, target={}, files={}",
+                    id, request.getTargetPath(), selectedFilesCount);
+
+            Long taskId = restoreService.startSelectiveRestore(id, request);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("taskId", taskId);
+            response.put("status", "EM_ANDAMENTO");
+            response.put("filesCount", selectedFilesCount);
+            response.put("message", "Restauração seletiva iniciada com sucesso");
+
+            return ResponseEntity.ok(response);
+
+        } catch (SecurityException e) {
+            logger.warn("Bloqueio de segurança: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            logger.warn("Erro de validação: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (Exception e) {
+            logger.error("Erro ao iniciar restauração seletiva: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao iniciar restauração: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/restore/{taskId}/cancel")
+    public ResponseEntity<?> cancelRestore(@PathVariable Long taskId) {
+        try {
+            logger.info("Cancelamento de restauração solicitado: taskId={}", taskId);
+
+            boolean success = restoreService.cancelRestore(taskId);
+
+            if (success) {
+                return ResponseEntity.ok(Map.of("message", "Restauração cancelada com sucesso"));
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Map.of("error", "Tarefa não encontrada ou não pode ser cancelada"));
+            }
+
+        } catch (Exception e) {
+            logger.error("Erro ao cancelar restauração: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao cancelar restauração: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/restore/{taskId}/status")
+    public ResponseEntity<?> getRestoreStatus(@PathVariable Long taskId) {
+        try {
+            Optional<RestoreTask> task = restoreRepository.findById(taskId);
+
+            if (task.isPresent()) {
+                return ResponseEntity.ok(task.get());
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Map.of("error", "Tarefa de restauração não encontrada"));
+            }
+
+        } catch (Exception e) {
+            logger.error("Erro ao buscar status: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao buscar status: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/restore/history")
+    public ResponseEntity<?> getRestoreHistory(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "startedAt") String sortBy,
+            @RequestParam(defaultValue = "DESC") Sort.Direction sortDir) {
+        try {
+            if (size < 1 || size > 100) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Tamanho da página deve estar entre 1 e 100"));
+            }
+
+            Pageable pageable = PageRequest.of(page, size, Sort.by(sortDir, sortBy));
+            Page<RestoreTask> history = restoreRepository.findAllOrderByStartedAtDesc(pageable);
+
+            return ResponseEntity.ok(history);
+
+        } catch (Exception e) {
+            logger.error("Erro ao buscar histórico: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao buscar histórico: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/restore/recent")
+    public ResponseEntity<?> getRecentRestores(
+            @RequestParam(defaultValue = "5") int limit) {
+        try {
+            if (limit < 1 || limit > 100) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Limite deve estar entre 1 e 100"));
+            }
+
+            Pageable pageable = PageRequest.of(0, limit);
+            List<RestoreTask> recent = restoreRepository.findTopNByOrderByStartedAtDesc(pageable);
+
+            return ResponseEntity.ok(recent);
+
+        } catch (Exception e) {
+            logger.error("Erro ao buscar restaurações recentes: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao buscar restaurações: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/backup/{id}/restore/history")
+    public ResponseEntity<?> getBackupRestoreHistory(@PathVariable Long id) {
+        try {
+            List<RestoreTask> history = restoreRepository.findByBackupId(id);
+            return ResponseEntity.ok(history);
+
+        } catch (Exception e) {
+            logger.error("Erro ao buscar histórico do backup: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Erro ao buscar histórico: " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/backup_manager/application/listener/RestoreEventListener.java
+++ b/src/main/java/com/backup_manager/application/listener/RestoreEventListener.java
@@ -1,0 +1,75 @@
+package com.backup_manager.application.listener;
+
+import com.backup_manager.application.service.EmailNotificationService;
+import com.backup_manager.domain.event.RestoreCancelledEvent;
+import com.backup_manager.domain.event.RestoreCompletedEvent;
+import com.backup_manager.domain.event.RestoreFailedEvent;
+import com.backup_manager.domain.event.RestoreStartedEvent;
+import com.backup_manager.domain.model.RestoreTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestoreEventListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestoreEventListener.class);
+
+    private final EmailNotificationService emailService;
+
+    public RestoreEventListener(EmailNotificationService emailService) {
+        this.emailService = emailService;
+    }
+
+    @EventListener
+    @Async
+    public void handleRestoreStarted(RestoreStartedEvent event) {
+        try {
+            RestoreTask task = event.getTask();
+            logger.info("Evento recebido: Restauração {} iniciada", task.getId());
+            emailService.sendRestoreStartedNotification(task);
+        } catch (Exception e) {
+            logger.error("Erro ao processar evento RestoreStarted: {}", e.getMessage(), e);
+        }
+    }
+
+    @EventListener
+    @Async
+    public void handleRestoreCompleted(RestoreCompletedEvent event) {
+        try {
+            RestoreTask task = event.getTask();
+            long duration = event.getDurationSeconds();
+            logger.info("Evento recebido: Restauração {} concluída ({}s)", task.getId(), duration);
+            emailService.sendRestoreCompletedNotification(task, duration);
+        } catch (Exception e) {
+            logger.error("Erro ao processar evento RestoreCompleted: {}", e.getMessage(), e);
+        }
+    }
+
+    @EventListener
+    @Async
+    public void handleRestoreFailed(RestoreFailedEvent event) {
+        try {
+            RestoreTask task = event.getTask();
+            String error = event.getErrorMessage();
+            logger.info("Evento recebido: Restauração {} falhou - {}", task.getId(), error);
+            emailService.sendRestoreFailedNotification(task, error);
+        } catch (Exception e) {
+            logger.error("Erro ao processar evento RestoreFailed: {}", e.getMessage(), e);
+        }
+    }
+
+    @EventListener
+    @Async
+    public void handleRestoreCancelled(RestoreCancelledEvent event) {
+        try {
+            RestoreTask task = event.getTask();
+            logger.info("Evento recebido: Restauração {} cancelada", task.getId());
+            emailService.sendRestoreCancelledNotification(task);
+        } catch (Exception e) {
+            logger.error("Erro ao processar evento RestoreCancelled: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/backup_manager/application/service/EmailNotificationService.java
+++ b/src/main/java/com/backup_manager/application/service/EmailNotificationService.java
@@ -1,6 +1,7 @@
 package com.backup_manager.application.service;
 
 import com.backup_manager.domain.model.BackupTask;
+import com.backup_manager.domain.model.RestoreTask;
 import com.backup_manager.infrastructure.config.NotificationProperties;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -23,7 +24,7 @@ import java.util.List;
 public class EmailNotificationService {
 
     private static final Logger logger = LoggerFactory.getLogger(EmailNotificationService.class);
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy 'às' HH:mm");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy 'as' HH:mm");
 
     private final JavaMailSender mailSender;
     private final NotificationProperties notificationProperties;
@@ -37,7 +38,7 @@ public class EmailNotificationService {
     @Async
     public void sendStartedNotification(BackupTask task, boolean isScheduled) {
         if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnStarted()) {
-            logger.debug("Notificação de início desabilitada");
+            logger.debug("Notificacao de inicio desabilitada");
             return;
         }
 
@@ -51,7 +52,7 @@ public class EmailNotificationService {
                                           List<String> destinations, LocalDateTime nextExecution,
                                           String cronExpression) {
         if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnScheduled()) {
-            logger.debug("Notificação de agendamento desabilitada");
+            logger.debug("Notificacao de agendamento desabilitada");
             return;
         }
 
@@ -63,11 +64,11 @@ public class EmailNotificationService {
     @Async
     public void sendSuccessNotification(BackupTask task, long durationSeconds) {
         if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnSuccess()) {
-            logger.debug("Notificação de sucesso desabilitada");
+            logger.debug("Notificacao de sucesso desabilitada");
             return;
         }
 
-        String subject = "Backup Concluído com Sucesso";
+        String subject = "Backup Concluido com Sucesso";
         String body = buildSuccessEmail(task, durationSeconds);
         sendEmail(subject, body);
     }
@@ -75,7 +76,7 @@ public class EmailNotificationService {
     @Async
     public void sendFailureNotification(BackupTask task, String errorMessage) {
         if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnFailure()) {
-            logger.debug("Notificação de falha desabilitada");
+            logger.debug("Notificacao de falha desabilitada");
             return;
         }
 
@@ -85,20 +86,65 @@ public class EmailNotificationService {
         try {
             sendEmailWithRetry(subject, body);
         } catch (MessagingException e) {
-            logger.error("Falha ao enviar email de falha após tentativas: {}", e.getMessage());
+            logger.error("Falha ao enviar email de falha apos tentativas: {}", e.getMessage());
         }
     }
 
     @Async
     public void sendCancellationNotification(BackupTask task) {
         if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnCancellation()) {
-            logger.debug("Notificação de cancelamento desabilitada");
+            logger.debug("Notificacao de cancelamento desabilitada");
             return;
         }
 
         String subject = "Backup Cancelado";
         String body = buildCancellationEmail(task);
         sendEmail(subject, body);
+    }
+
+    @Async
+    public void sendRestoreStartedNotification(RestoreTask task) {
+        if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnStarted()) {
+            logger.debug("Notificacao de inicio de restauracao desabilitada");
+            return;
+        }
+
+        sendEmail("Restauracao Iniciada", buildRestoreStartedEmail(task));
+    }
+
+    @Async
+    public void sendRestoreCompletedNotification(RestoreTask task, long durationSeconds) {
+        if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnSuccess()) {
+            logger.debug("Notificacao de sucesso de restauracao desabilitada");
+            return;
+        }
+
+        sendEmail("Restauracao Concluida com Sucesso",
+                buildRestoreCompletedEmail(task, durationSeconds));
+    }
+
+    @Async
+    public void sendRestoreFailedNotification(RestoreTask task, String errorMessage) {
+        if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnFailure()) {
+            logger.debug("Notificacao de falha de restauracao desabilitada");
+            return;
+        }
+
+        try {
+            sendEmailWithRetry("Falha na Restauracao", buildRestoreFailureEmail(task, errorMessage));
+        } catch (MessagingException e) {
+            logger.error("Falha ao enviar email de restauracao apos tentativas: {}", e.getMessage());
+        }
+    }
+
+    @Async
+    public void sendRestoreCancelledNotification(RestoreTask task) {
+        if (!shouldSendEmail() || !notificationProperties.getEmail().isNotifyOnCancellation()) {
+            logger.debug("Notificacao de cancelamento de restauracao desabilitada");
+            return;
+        }
+
+        sendEmail("Restauracao Cancelada", buildRestoreCancellationEmail(task));
     }
 
     public boolean sendTestEmail() {
@@ -123,7 +169,7 @@ public class EmailNotificationService {
         List<String> recipients = notificationProperties.getEmail().getRecipients();
 
         if (recipients == null || recipients.isEmpty()) {
-            logger.warn("Nenhum destinatário configurado em notification.email.recipients");
+            logger.warn("Nenhum destinatario configurado em notification.email.recipients");
             return;
         }
 
@@ -153,7 +199,7 @@ public class EmailNotificationService {
         List<String> recipients = notificationProperties.getEmail().getRecipients();
 
         if (recipients == null || recipients.isEmpty()) {
-            logger.warn("Nenhum destinatário configurado");
+            logger.warn("Nenhum destinatario configurado");
             return;
         }
 
@@ -166,14 +212,13 @@ public class EmailNotificationService {
         helper.setText(body, true);
 
         mailSender.send(message);
-        logger.info("Email crítico enviado: '{}'", subject);
+        logger.info("Email critico enviado: '{}'", subject);
     }
 
     @Recover
     public void recoverFromEmailFailure(MessagingException e, String subject, String body) {
-        logger.error("FALHA DEFINITIVA ao enviar email crítico '{}' após 3 tentativas: {}",
+        logger.error("Falha definitiva ao enviar email critico '{}' apos 3 tentativas: {}",
                 subject, e.getMessage());
-        // Aqui você poderia: salvar em fila de emails pendentes, alertar administrador, etc.
     }
 
     private boolean shouldSendEmail() {
@@ -202,7 +247,7 @@ public class EmailNotificationService {
                         </div>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>
@@ -230,13 +275,13 @@ public class EmailNotificationService {
                         <p><strong>Nome:</strong> %s</p>
                         <p><strong>Origem(s):</strong> %s</p>
                         <p><strong>Destino(s):</strong> %s</p>
-                        <p><strong>Expressão Cron:</strong> <code>%s</code></p>
+                        <p><strong>Expressao Cron:</strong> <code>%s</code></p>
                         <div style="background: #f3e5f5; border-left: 4px solid #9C27B0; padding: 15px; margin: 15px 0;">
-                            <strong>Próxima Execução:</strong><br>%s
+                            <strong>Proxima Execucao:</strong><br>%s
                         </div>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>
@@ -257,19 +302,19 @@ public class EmailNotificationService {
             <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
                 <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
                     <div style="background: #4CAF50; color: white; padding: 20px; border-radius: 5px;">
-                        <h1>Backup Concluído com Sucesso</h1>
+                        <h1>Backup Concluido com Sucesso</h1>
                     </div>
                     <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
                         <p><strong>ID:</strong> %d</p>
                         <p><strong>Origem:</strong> %s</p>
                         <p><strong>Destino:</strong> %s</p>
-                        <p><strong>Concluído em:</strong> %s</p>
-                        <p><strong>Duração:</strong> %s</p>
+                        <p><strong>Concluido em:</strong> %s</p>
+                        <p><strong>Duracao:</strong> %s</p>
                         <p><strong>Tamanho:</strong> %s</p>
                         <p><strong>Arquivos:</strong> %s</p>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>
@@ -293,13 +338,13 @@ public class EmailNotificationService {
                     <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
                         <p><strong>ID:</strong> %d</p>
                         <p><strong>Origem:</strong> %s</p>
-                        <p><strong>Horário:</strong> %s</p>
+                        <p><strong>Horario:</strong> %s</p>
                         <div style="background: #ffebee; border-left: 4px solid #f44336; padding: 15px; margin: 15px 0;">
                             <strong>Erro:</strong><br>%s
                         </div>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>
@@ -323,16 +368,122 @@ public class EmailNotificationService {
                     <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
                         <p><strong>ID:</strong> %d</p>
                         <p><strong>Origem:</strong> %s</p>
-                        <p><strong>Horário:</strong> %s</p>
+                        <p><strong>Horario:</strong> %s</p>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>
             </html>
             """,
                 task.getId(), task.getSourcePath(), startedAt
+        );
+    }
+
+    private String buildRestoreStartedEmail(RestoreTask task) {
+        String startedAt = task.getStartedAt() != null ? task.getStartedAt().format(DATE_FORMATTER) : "N/A";
+        String restoreType = task.getRestoreType() != null ? task.getRestoreType().name() : "N/A";
+        String backupPath = task.getSourceBackup() != null ? task.getSourceBackup().getDestinationPath() : "N/A";
+
+        return String.format("""
+            <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                    <div style="background: #1565C0; color: white; padding: 20px; border-radius: 5px;">
+                        <h1>Restauracao Iniciada</h1>
+                    </div>
+                    <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
+                        <p><strong>ID:</strong> %d</p>
+                        <p><strong>Tipo:</strong> %s</p>
+                        <p><strong>Backup:</strong> %s</p>
+                        <p><strong>Destino:</strong> %s</p>
+                        <p><strong>Iniciada em:</strong> %s</p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """,
+                task.getId(), restoreType, backupPath, task.getTargetPath(), startedAt
+        );
+    }
+
+    private String buildRestoreCompletedEmail(RestoreTask task, long durationSeconds) {
+        String finishedAt = task.getFinishedAt() != null ? task.getFinishedAt().format(DATE_FORMATTER) : "N/A";
+        String restoredFiles = task.getRestoredFiles() != null ? task.getRestoredFiles().toString() : "N/A";
+        String size = task.getTotalSizeMB() != null ? task.getTotalSizeMB() + " MB" : "N/A";
+
+        return String.format("""
+            <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                    <div style="background: #2E7D32; color: white; padding: 20px; border-radius: 5px;">
+                        <h1>Restauracao Concluida</h1>
+                    </div>
+                    <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
+                        <p><strong>ID:</strong> %d</p>
+                        <p><strong>Destino:</strong> %s</p>
+                        <p><strong>Concluida em:</strong> %s</p>
+                        <p><strong>Duracao:</strong> %s</p>
+                        <p><strong>Arquivos restaurados:</strong> %s</p>
+                        <p><strong>Tamanho restaurado:</strong> %s</p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """,
+                task.getId(), task.getTargetPath(), finishedAt, formatDuration(durationSeconds),
+                restoredFiles, size
+        );
+    }
+
+    private String buildRestoreFailureEmail(RestoreTask task, String errorMessage) {
+        String startedAt = task.getStartedAt() != null ? task.getStartedAt().format(DATE_FORMATTER) : "N/A";
+
+        return String.format("""
+            <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                    <div style="background: #C62828; color: white; padding: 20px; border-radius: 5px;">
+                        <h1>Falha na Restauracao</h1>
+                    </div>
+                    <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
+                        <p><strong>ID:</strong> %d</p>
+                        <p><strong>Destino:</strong> %s</p>
+                        <p><strong>Iniciada em:</strong> %s</p>
+                        <div style="background: #ffebee; border-left: 4px solid #C62828; padding: 15px; margin: 15px 0;">
+                            <strong>Erro:</strong><br>%s
+                        </div>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """,
+                task.getId(), task.getTargetPath(), startedAt,
+                errorMessage != null ? errorMessage : "Erro desconhecido"
+        );
+    }
+
+    private String buildRestoreCancellationEmail(RestoreTask task) {
+        String startedAt = task.getStartedAt() != null ? task.getStartedAt().format(DATE_FORMATTER) : "N/A";
+
+        return String.format("""
+            <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                    <div style="background: #EF6C00; color: white; padding: 20px; border-radius: 5px;">
+                        <h1>Restauracao Cancelada</h1>
+                    </div>
+                    <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
+                        <p><strong>ID:</strong> %d</p>
+                        <p><strong>Destino:</strong> %s</p>
+                        <p><strong>Iniciada em:</strong> %s</p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """,
+                task.getId(), task.getTargetPath(), startedAt
         );
     }
 
@@ -346,12 +497,12 @@ public class EmailNotificationService {
                     </div>
                     <div style="background: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px;">
                         <div style="background: #d4edda; border-left: 4px solid #28a745; padding: 15px;">
-                            <strong>✓ Configuração funcionando!</strong><br>
-                            Você receberá notificações de backups.
+                            <strong>Configuracao funcionando!</strong><br>
+                            Voce recebera notificacoes de backups.
                         </div>
                     </div>
                     <p style="color: #666; font-size: 12px; text-align: center; margin-top: 20px;">
-                        Sistema de Backups Automáticos
+                        Sistema de Backups Automaticos
                     </p>
                 </div>
             </body>

--- a/src/main/java/com/backup_manager/application/service/RestoreService.java
+++ b/src/main/java/com/backup_manager/application/service/RestoreService.java
@@ -1,0 +1,433 @@
+package com.backup_manager.application.service;
+
+import com.backup_manager.application.dto.FileNodeDTO;
+import com.backup_manager.application.dto.FileTreeDTO;
+import com.backup_manager.application.dto.RestoreRequest;
+import com.backup_manager.application.dto.SelectiveRestoreRequest;
+import com.backup_manager.domain.event.RestoreCompletedEvent;
+import com.backup_manager.domain.event.RestoreFailedEvent;
+import com.backup_manager.domain.event.RestoreStartedEvent;
+import com.backup_manager.domain.model.BackupTask;
+import com.backup_manager.domain.model.RestoreStatus;
+import com.backup_manager.domain.model.RestoreTask;
+import com.backup_manager.domain.model.RestoreType;
+import com.backup_manager.domain.service.RestoreTaskManager;
+import com.backup_manager.infrastructure.persistence.BackupRepository;
+import com.backup_manager.infrastructure.persistence.RestoreRepository;
+import com.backup_manager.infrastructure.storage.FileRestoreOperations;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+public class RestoreService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestoreService.class);
+
+    private final BackupRepository backupRepository;
+    private final RestoreRepository restoreRepository;
+    private final RestoreTaskManager taskManager;
+    private final FileRestoreOperations restoreOps;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+    private final RestoreService self;
+
+    public RestoreService(BackupRepository backupRepository,
+                          RestoreRepository restoreRepository,
+                          RestoreTaskManager taskManager,
+                          FileRestoreOperations restoreOps,
+                          ApplicationEventPublisher eventPublisher,
+                          ObjectMapper objectMapper,
+                          @Lazy RestoreService self) {
+        this.backupRepository = backupRepository;
+        this.restoreRepository = restoreRepository;
+        this.taskManager = taskManager;
+        this.restoreOps = restoreOps;
+        this.eventPublisher = eventPublisher;
+        this.objectMapper = objectMapper;
+        this.self = self;
+    }
+
+    public FileTreeDTO previewFiles(Long backupId) throws IOException {
+        logger.info("Gerando preview de arquivos para backup ID={}", backupId);
+
+        BackupTask backup = backupRepository.findById(backupId)
+                .orElseThrow(() -> new IllegalArgumentException("Backup não encontrado: " + backupId));
+
+        Path backupPath = Paths.get(backup.getDestinationPath());
+
+        if (!Files.exists(backupPath)) {
+            throw new IllegalStateException("Backup não encontrado no disco: " + backupPath);
+        }
+
+        // Materializa a listagem uma vez dentro do try-with-resources para evitar handles abertos.
+        List<Path> backupEntries;
+        try (Stream<Path> stream = Files.list(backupPath)) {
+            backupEntries = stream.toList();
+        }
+
+        if (backupEntries.isEmpty()) {
+            throw new IllegalStateException("Backup vazio: " + backupPath);
+        }
+
+        List<FileNodeDTO> files = new ArrayList<>();
+        long[] totalFiles = {0};
+        long[] totalSize = {0};
+
+        backupEntries.forEach(path -> {
+            try {
+                FileNodeDTO node = buildFileNode(path, backupPath);
+                files.add(node);
+
+                if ("directory".equals(node.getType())) {
+                    totalFiles[0] += node.getFileCount();
+                } else {
+                    totalFiles[0]++;
+                }
+
+                totalSize[0] += node.getSizeMB().multiply(BigDecimal.valueOf(1024 * 1024)).longValue();
+            } catch (IOException e) {
+                logger.warn("Erro ao processar arquivo {}: {}", path, e.getMessage());
+            }
+        });
+
+        BigDecimal totalSizeMB = BigDecimal.valueOf(totalSize[0])
+                .divide(BigDecimal.valueOf(1024 * 1024), 2, RoundingMode.HALF_UP);
+
+        FileTreeDTO tree = new FileTreeDTO();
+        tree.setBackupId(backupId);
+        tree.setSourcePath(backup.getSourcePath());
+        tree.setBackupPath(backup.getDestinationPath());
+        tree.setBackupDate(backup.getFinishedAt());
+        tree.setTotalFiles(totalFiles[0]);
+        tree.setTotalSizeMB(totalSizeMB);
+        tree.setFiles(files);
+
+        logger.info("Preview gerado: {} arquivos, {} MB", totalFiles[0], totalSizeMB);
+        return tree;
+    }
+
+    private FileNodeDTO buildFileNode(Path path, Path root) throws IOException {
+        BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+        Path relativePath = root.relativize(path);
+
+        FileNodeDTO node = new FileNodeDTO();
+        node.setName(path.getFileName().toString());
+        node.setRelativePath(relativePath.toString());
+        node.setLastModified(LocalDateTime.ofInstant(
+                attrs.lastModifiedTime().toInstant(),
+                java.time.ZoneId.systemDefault()
+        ));
+
+        if (Files.isDirectory(path)) {
+            node.setType("directory");
+
+            long[] count = {0};
+            long[] size = {0};
+
+            try (Stream<Path> walk = Files.walk(path)) {
+                walk.forEach(p -> {
+                    try {
+                        if (Files.isRegularFile(p)) {
+                            count[0]++;
+                            size[0] += Files.size(p);
+                        }
+                    } catch (IOException e) {
+                        logger.debug("Erro ao processar {}: {}", p, e.getMessage());
+                    }
+                });
+            }
+
+            node.setFileCount(count[0]);
+            node.setSizeMB(BigDecimal.valueOf(size[0])
+                    .divide(BigDecimal.valueOf(1024 * 1024), 2, RoundingMode.HALF_UP));
+            node.setChildren(null); // Não carregar subárvore completa para performance
+        } else {
+            node.setType("file");
+            node.setSizeMB(BigDecimal.valueOf(attrs.size())
+                    .divide(BigDecimal.valueOf(1024 * 1024), 2, RoundingMode.HALF_UP));
+            node.setFileCount(null);
+            node.setChildren(null);
+        }
+
+        return node;
+    }
+
+    public Long startFullRestore(Long backupId, RestoreRequest request) throws IOException {
+        logger.info("Iniciando restauração completa: backupId={}, target={}",
+                backupId, request.getTargetPath());
+
+        BackupTask backup = validateBackup(backupId);
+        validateRestorePath(request.getTargetPath());
+
+        RestoreTask task = createRestoreTask(backup, request.getTargetPath(),
+                RestoreType.FULL, null);
+        task = restoreRepository.save(task);
+
+        final Long taskId = task.getId();
+        // Usa o proxy Spring para que @Async seja realmente aplicado.
+        self.processRestoreAsync(task, request.isOverwriteExisting(), null);
+
+        return taskId;
+    }
+
+    public Long startSelectiveRestore(Long backupId, SelectiveRestoreRequest request) throws IOException {
+        logger.info("Iniciando restauração seletiva: backupId={}, target={}, selectedFiles={}",
+                backupId, request.getTargetPath(),
+                request.getSelectedFiles() != null ? request.getSelectedFiles().size() : 0);
+
+        BackupTask backup = validateBackup(backupId);
+        Path backupRoot = Paths.get(backup.getDestinationPath());
+
+        validateRestorePath(request.getTargetPath());
+        validateSelectedFiles(request.getSelectedFiles(), backupRoot);
+
+        RestoreTask task = createRestoreTask(
+                backup,
+                request.getTargetPath(),
+                RestoreType.SELECTIVE,
+                serializeSelectedFiles(request.getSelectedFiles())
+        );
+        task = restoreRepository.save(task);
+
+        // Usa o proxy Spring para que @Async seja realmente aplicado.
+        self.processRestoreAsync(task, request.isOverwriteExisting(), request.getSelectedFiles());
+        return task.getId();
+    }
+
+    @Async
+    public void processRestoreAsync(RestoreTask task, boolean overwriteExisting,
+                                    List<String> selectedFiles) {
+        try {
+            logger.info("Iniciando processamento de restauração: ID={}", task.getId());
+
+            taskManager.registerTask(task.getId(), task);
+            eventPublisher.publishEvent(new RestoreStartedEvent(task));
+
+            Path backupSource = Paths.get(task.getSourceBackup().getDestinationPath());
+            Path targetDestination = Paths.get(task.getTargetPath());
+
+            try {
+                FileRestoreOperations.RestoreResult result;
+
+                if (task.getRestoreType() == RestoreType.FULL) {
+                    result = restoreOps.restoreAll(backupSource, targetDestination,
+                            overwriteExisting, createCallback(task.getId()));
+                } else {
+                    result = restoreOps.restoreSelective(backupSource, targetDestination,
+                            selectedFiles, overwriteExisting,
+                            createCallback(task.getId()));
+                }
+
+                RestoreTask memoryTask = taskManager.getTask(task.getId());
+
+                if (memoryTask != null &&
+                        (memoryTask.isCancelled() || memoryTask.getStatus() == RestoreStatus.CANCELADO)) {
+                    logger.info("Restauração {} cancelada durante execução", task.getId());
+                } else {
+                    finalizeRestore(task, result);
+                }
+
+            } catch (Exception e) {
+                RestoreTask memoryTask = taskManager.getTask(task.getId());
+
+                if (memoryTask != null &&
+                        (memoryTask.isCancelled() || memoryTask.getStatus() == RestoreStatus.CANCELADO)) {
+                    logger.info("Restauração {} cancelada (exception capturada)", task.getId());
+                } else {
+                    handleRestoreFailure(task, e);
+                }
+            } finally {
+                RestoreTask memoryTask = taskManager.getTask(task.getId());
+
+                if (memoryTask != null &&
+                        (memoryTask.isCancelled() || memoryTask.getStatus() == RestoreStatus.CANCELADO)) {
+                    logger.info("Finally: Restauração {} cancelada, não sobrescreve estado", task.getId());
+                    taskManager.unregisterTask(task.getId());
+                    return;
+                }
+
+                RestoreTask finalTask = restoreRepository.findById(task.getId()).orElse(task);
+
+                if (finalTask.getFinishedAt() == null) {
+                    finalTask.setFinishedAt(LocalDateTime.now());
+                    restoreRepository.save(finalTask);
+                }
+
+                taskManager.unregisterTask(task.getId());
+            }
+
+        } catch (Exception e) {
+            logger.error("Erro crítico no processamento da restauração {}: {}",
+                    task.getId(), e.getMessage(), e);
+        }
+    }
+
+    private FileRestoreOperations.RestoreProgressCallback createCallback(Long taskId) {
+        return new FileRestoreOperations.RestoreProgressCallback() {
+            @Override
+            public void onFileRestored(Path file, BasicFileAttributes attrs) {}
+
+            @Override
+            public void onWarning(String message, Path path) {
+                logger.warn("Restauração {}: {} - {}", taskId, message, path);
+            }
+
+            @Override
+            public boolean shouldContinue() {
+                RestoreTask task = taskManager.getTask(taskId);
+                return task != null && !task.isCancelled();
+            }
+
+            @Override
+            public void onProgress(int processed, int total) {
+                taskManager.updateProgress(taskId, processed);
+            }
+        };
+    }
+
+    private void finalizeRestore(RestoreTask task, FileRestoreOperations.RestoreResult result) {
+        logger.info("Finalizando restauração {}: {} arquivos restaurados",
+                task.getId(), result.getFilesRestored());
+
+        // Define o timestamp antes do cálculo para não publicar duração zerada nos eventos.
+        task.setFinishedAt(LocalDateTime.now());
+        long durationSeconds = calculateDuration(task);
+
+        task.setFileCount((long) result.getFilesRestored());
+        task.setRestoredFiles((long) result.getFilesRestored());
+        task.setTotalSizeMB(BigDecimal.valueOf(result.getTotalBytes())
+                .divide(BigDecimal.valueOf(1024 * 1024), 2, RoundingMode.HALF_UP));
+        task.setStatus(RestoreStatus.CONCLUIDO);
+
+        if (result.getWarnings() > 0) {
+            task.setErrorMessage("Concluído com " + result.getWarnings() + " avisos");
+        }
+
+        restoreRepository.save(task);
+        eventPublisher.publishEvent(new RestoreCompletedEvent(task, durationSeconds));
+    }
+
+    private void handleRestoreFailure(RestoreTask task, Exception e) {
+        logger.error("Falha na restauração {}: {}", task.getId(), e.getMessage());
+
+        task.setStatus(RestoreStatus.FALHA);
+        task.setErrorMessage(e.getMessage());
+        task.setFinishedAt(LocalDateTime.now());
+
+        restoreRepository.save(task);
+        eventPublisher.publishEvent(new RestoreFailedEvent(task, e.getMessage()));
+    }
+
+    private BackupTask validateBackup(Long backupId) {
+        BackupTask backup = backupRepository.findById(backupId)
+                .orElseThrow(() -> new IllegalArgumentException("Backup não encontrado: " + backupId));
+
+        Path backupPath = Paths.get(backup.getDestinationPath());
+        if (!Files.exists(backupPath)) {
+            throw new IllegalStateException("Backup não encontrado no disco: " + backupPath);
+        }
+
+        return backup;
+    }
+
+    private void validateRestorePath(String targetPath) {
+        if (targetPath == null || targetPath.isBlank()) {
+            throw new IllegalArgumentException("Caminho de destino não pode estar vazio");
+        }
+
+        Path normalized = Paths.get(targetPath).normalize().toAbsolutePath();
+
+        if (targetPath.contains("..")) {
+            throw new SecurityException("Path traversal detectado: " + targetPath);
+        }
+
+        String normalizedPath = normalized.toString().toLowerCase();
+        String rootDir = System.getenv("SystemRoot");
+        String windowsDir = (rootDir != null) ? rootDir.toLowerCase() : "c:\\windows";
+
+        boolean isForbidden = normalizedPath.startsWith(windowsDir) ||
+                normalizedPath.contains("system32") ||
+                normalizedPath.contains("syswow64") ||
+                normalizedPath.contains("program files") ||
+                normalizedPath.matches("^[a-z]:\\\\$");
+
+        if (isForbidden) {
+            throw new SecurityException("Restauração em pasta do sistema não permitida: " + targetPath);
+        }
+
+        Path parent = normalized.getParent();
+        if (parent != null && Files.exists(parent) && !Files.isWritable(parent)) {
+            throw new SecurityException("Sem permissão de escrita no destino: " + targetPath);
+        }
+    }
+
+    private void validateSelectedFiles(List<String> selectedFiles, Path backupRoot) {
+        if (selectedFiles == null || selectedFiles.isEmpty()) {
+            throw new IllegalArgumentException("Lista de arquivos selecionados não pode estar vazia");
+        }
+
+        for (String file : selectedFiles) {
+            Path filePath = backupRoot.resolve(file).normalize();
+
+            if (!filePath.startsWith(backupRoot)) {
+                throw new SecurityException("Path fora do backup: " + file);
+            }
+        }
+    }
+
+    private RestoreTask createRestoreTask(BackupTask backup, String targetPath,
+                                          RestoreType type, String selectedFiles) {
+        RestoreTask task = new RestoreTask();
+        task.setSourceBackup(backup);
+        task.setTargetPath(targetPath);
+        task.setRestoreType(type);
+        task.setSelectedFiles(selectedFiles);
+        task.setStatus(RestoreStatus.EM_ANDAMENTO);
+        task.setStartedAt(LocalDateTime.now());
+        return task;
+    }
+
+    private String serializeSelectedFiles(List<String> selectedFiles) {
+        try {
+            return objectMapper.writeValueAsString(selectedFiles);
+        } catch (JsonProcessingException e) {
+            logger.error("Erro ao serializar arquivos selecionados: {}", e.getMessage());
+            return "[]";
+        }
+    }
+
+    private long calculateDuration(RestoreTask task) {
+        if (task.getStartedAt() != null && task.getFinishedAt() != null) {
+            return java.time.temporal.ChronoUnit.SECONDS.between(
+                    task.getStartedAt(), task.getFinishedAt()
+            );
+        }
+        return 0;
+    }
+
+    public boolean cancelRestore(Long taskId) {
+        return taskManager.cancelTask(taskId);
+    }
+
+    public List<RestoreTask> getAllRestores() {
+        return restoreRepository.findAll();
+    }
+}

--- a/src/main/java/com/backup_manager/application/service/RestoreService.java
+++ b/src/main/java/com/backup_manager/application/service/RestoreService.java
@@ -54,14 +54,13 @@ public class RestoreService {
                           RestoreTaskManager taskManager,
                           FileRestoreOperations restoreOps,
                           ApplicationEventPublisher eventPublisher,
-                          ObjectMapper objectMapper,
                           @Lazy RestoreService self) {
         this.backupRepository = backupRepository;
         this.restoreRepository = restoreRepository;
         this.taskManager = taskManager;
         this.restoreOps = restoreOps;
         this.eventPublisher = eventPublisher;
-        this.objectMapper = objectMapper;
+        this.objectMapper = new ObjectMapper();
         this.self = self;
     }
 

--- a/src/main/java/com/backup_manager/domain/model/RestoreType.java
+++ b/src/main/java/com/backup_manager/domain/model/RestoreType.java
@@ -2,5 +2,5 @@ package com.backup_manager.domain.model;
 
 public enum RestoreType {
     FULL,
-    INCREMENTAL
+    SELECTIVE
 }


### PR DESCRIPTION
## Resumo das alteracoes feitas
- implementa o servico e o controller de restauracao com suporte a preview, restauracao completa, restauracao seletiva, cancelamento e historico
- adiciona listener de eventos de restauracao e notificacoes por email para inicio, conclusao, falha e cancelamento
- corrige execucao assincrona da restauracao via proxy Spring e fecha streams abertos no preview para evitar vazamento de recursos
- corrige o calculo de duracao da restauracao e protege o endpoint seletivo contra NullPointerException

## Descobertas resolvidas
- chamada para 
estoreService.startSelectiveRestore(...) sem implementacao concreta em RestoreService
- chamadas para sendRestore*Notification(...) sem metodos correspondentes em EmailNotificationService
- @Async em autoinvocacao da RestoreService, fazendo a restauracao poder rodar de forma sincrona
- Files.list(...) e Files.walk(...) sem fechamento garantido em RestoreService, com risco de vazamento de handles
- duracao de restauracao calculada antes de definir inishedAt, gerando notificacoes com tempo zerado
- acesso a 
equest.getSelectedFiles().size() sem checagem nula no controller seletivo
