### PR TITLE
fix: corrigir metricas de storage e endurecer scheduler

### DIFF
--- a/src/main/java/com/backup_manager/application/controller/BackupSchedulerController.java
+++ b/src/main/java/com/backup_manager/application/controller/BackupSchedulerController.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -87,18 +88,12 @@ public class BackupSchedulerController {
             return ResponseEntity.ok(response);
 
         } catch (IllegalArgumentException e) {
-            Map<String, Object> error = new HashMap<>();
-            error.put("success", false);
-            error.put("error", e.getMessage());
-            return ResponseEntity.badRequest().body(error);
+            logger.warn("Falha de validacao ao agendar backup: {}", e.getMessage());
+            return errorResponse(HttpStatus.BAD_REQUEST, "Nao foi possivel agendar o backup com os dados informados.");
 
         } catch (Exception e) {
             logger.error("Erro ao agendar backup: {}", e.getMessage(), e);
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("success", false);
-            error.put("error", "Erro interno ao agendar backup");
-            return ResponseEntity.internalServerError().body(error);
+            return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Erro interno ao agendar backup.");
         }
     }
 
@@ -127,12 +122,7 @@ public class BackupSchedulerController {
             return ResponseEntity.status(404).body(error);
         } catch (Exception e) {
             logger.error("Erro ao cancelar backup {}: {}", taskId, e.getMessage(), e);
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("success", false);
-            error.put("error", "Erro interno ao cancelar backup");
-            error.put("taskId", taskId);
-            return ResponseEntity.internalServerError().body(error);
+            return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Erro interno ao cancelar backup.");
         }
     }
 
@@ -150,11 +140,7 @@ public class BackupSchedulerController {
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             logger.error("Erro ao listar backups pendentes: {}", e.getMessage(), e);
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("success", false);
-            error.put("error", "Erro interno ao listar backups pendentes");
-            return ResponseEntity.internalServerError().body(error);
+            return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Erro interno ao listar backups pendentes.");
         }
     }
 
@@ -176,12 +162,7 @@ public class BackupSchedulerController {
 
         } catch (Exception e) {
             logger.error("Erro ao executar backup imediato: {}", e.getMessage(), e);
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("success", false);
-            error.put("error", "Falha ao executar backup imediato.");
-
-            return ResponseEntity.badRequest().body(error);
+            return errorResponse(HttpStatus.BAD_REQUEST, "Falha ao executar backup imediato.");
         }
     }
 
@@ -194,8 +175,6 @@ public class BackupSchedulerController {
             health.put("status", "UP");
             health.put("timestamp", LocalDateTime.now().toString());
             health.put("schedulerEnabled", status.isEnabled());
-            health.put("activeConfigurations", status.getEnabledConfigurations());
-            health.put("recentExecutions", status.getRecentExecutions());
             health.put("service", "backup-scheduler");
 
             return ResponseEntity.ok(health);
@@ -214,5 +193,12 @@ public class BackupSchedulerController {
     @PreDestroy
     public void cleanup() {
         logger.info("Desligando controller do scheduler...");
+    }
+
+    private ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String message) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("success", false);
+        error.put("error", message);
+        return ResponseEntity.status(status).body(error);
     }
 }

--- a/src/main/java/com/backup_manager/application/controller/LogController.java
+++ b/src/main/java/com/backup_manager/application/controller/LogController.java
@@ -1,6 +1,6 @@
 package com.backup_manager.application.controller;
 
-import com.backup_manager.infrastructure.logging.BackupContext;
+import com.backup_manager.infrastructure.logging.LogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,24 +8,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/logs")
 public class LogController {
 
-    private final BackupContext backupContext;
+    private final LogService logService;
 
-    public LogController(BackupContext backupContext) {
-        this.backupContext = backupContext;
+    public LogController(LogService logService) {
+        this.logService = logService;
     }
 
     @GetMapping
     public ResponseEntity<?> getLogStatus() {
-        String lastDest = backupContext.getLastDestination();
-        if (lastDest == null) {
+        try {
+            logService.resolveLatestWarningsLog();
+        } catch (IOException e) {
             return ResponseEntity.ok(Map.of("status", "No backups executed yet in this session."));
         }
 
@@ -38,28 +37,15 @@ public class LogController {
     @GetMapping("/warnings")
     public ResponseEntity<String> getWarningsLog() {
         try {
-            String lastDest = backupContext.getLastDestination();
-
-            if (lastDest == null) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body("Nenhum backup foi executado nesta sessao ainda.");
-            }
-
-            Path logPath = Path.of(lastDest, "warnings.log");
-            if (!Files.exists(logPath)) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body("O arquivo warnings.log nao foi encontrado.");
-            }
-
-            String content = Files.readString(logPath);
+            String content = logService.redLog(logService.resolveLatestWarningsLog());
             if (content.isBlank()) {
                 return ResponseEntity.ok("Nenhum alerta encontrado.");
             }
 
             return ResponseEntity.ok(content);
         } catch (IOException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Erro interno ao ler warnings.log.");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Nenhum warnings.log disponivel para consulta.");
         }
     }
 }

--- a/src/main/java/com/backup_manager/application/service/SystemStorageService.java
+++ b/src/main/java/com/backup_manager/application/service/SystemStorageService.java
@@ -23,7 +23,7 @@ public class SystemStorageService {
 
             long totalSpace = root.getTotalSpace();
             long usableSpace = root.getUsableSpace();
-            long usedSpace = root.getUsableSpace();
+            long usedSpace = totalSpace - usableSpace;
 
             double usagePercent = ((double) usedSpace / totalSpace) * 100;
 

--- a/src/main/java/com/backup_manager/infrastructure/logging/LogService.java
+++ b/src/main/java/com/backup_manager/infrastructure/logging/LogService.java
@@ -82,8 +82,8 @@ public class LogService {
 
     private Optional<Path> latestWarningsUnderBase(Path base) {
         if (!Files.exists(base)) return Optional.empty();
-        try {
-            return Files.walk(base, 5)
+        try (var walk = Files.walk(base, 5)) {
+            return walk
                     .filter(p -> p.getFileName().toString().equalsIgnoreCase("warnings.log"))
                     .max(Comparator.comparing(this::safeLastModified));
         } catch (java.io.IOException e) {


### PR DESCRIPTION
## Resumo
- corrige o calculo de espaco usado no endpoint de storage
- fecha corretamente a varredura de `warnings.log` para evitar vazamento de recursos
- passa a usar `LogService` no controller de logs
- sanitiza respostas de erro do scheduler e reduz detalhes do health operacional

## Melhorias aplicadas
- `SystemStorageService`: `usedSpace` agora usa `totalSpace - usableSpace`
- `LogService`: `Files.walk(...)` agora e fechado com `try-with-resources`
- `LogController`: leitura de logs centralizada no servico e retorno `404` coerente quando nao ha `warnings.log`
- `BackupSchedulerController`: remove `e.getMessage()` das respostas e reduz campos expostos em `/health`