### PR TITLE
security: endurecer configuracao e autenticacao por ambiente

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 			<artifactId>flyway-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/src/main/java/com/backup_manager/infrastructure/config/AppSecurityProperties.java
+++ b/src/main/java/com/backup_manager/infrastructure/config/AppSecurityProperties.java
@@ -4,14 +4,25 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
 
 @Getter
 @Setter
 @Component
+@Validated
 @ConfigurationProperties(prefix = "app.security")
 public class AppSecurityProperties {
 
+    @NotBlank
     private String username = "admin";
+
+    @NotBlank
     private String password = "change-me-now";
+
+    @NotBlank
     private String role = "ADMIN";
+
+    private boolean allowDefaultPassword = false;
 }

--- a/src/main/java/com/backup_manager/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/backup_manager/infrastructure/config/SecurityConfig.java
@@ -43,6 +43,11 @@ public class SecurityConfig {
     public UserDetailsService userDetailsService(AppSecurityProperties securityProperties,
                                                  PasswordEncoder passwordEncoder) {
         if ("change-me-now".equals(securityProperties.getPassword())) {
+            if (!securityProperties.isAllowDefaultPassword()) {
+                throw new IllegalStateException(
+                        "APP_SECURITY_PASSWORD precisa ser definido fora do valor default para subir a aplicacao neste ambiente."
+                );
+            }
             logger.warn("Usando senha default de seguranca. Defina APP_SECURITY_PASSWORD no ambiente.");
         }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,1 @@
-spring.jpa.hibernate.ddl-auto=validate
 app.security.allow-default-password=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,2 +1,2 @@
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=create-drop
 app.security.allow-default-password=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,3 +41,4 @@ spring.mail.properties.mail.smtp.starttls.required=false
 app.security.username=${APP_SECURITY_USERNAME:admin}
 app.security.password=${APP_SECURITY_PASSWORD:change-me-now}
 app.security.role=${APP_SECURITY_ROLE:ADMIN}
+app.security.allow-default-password=${APP_SECURITY_ALLOW_DEFAULT_PASSWORD:false}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${D
 spring.datasource.username=${DB_USERNAME:postgres}
 spring.datasource.password=${DB_PASSWORD:}
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
 

--- a/src/test/java/com/backup_manager/BackupManagerApplicationTests.java
+++ b/src/test/java/com/backup_manager/BackupManagerApplicationTests.java
@@ -2,8 +2,10 @@ package com.backup_manager;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackupManagerApplicationTests {
 
 	@Test


### PR DESCRIPTION
## Resumo
- alinha o schema runtime ao Flyway, removendo `ddl-auto=update`
- explicita o perfil de teste para o teste de contexto
- endurece a autenticacao para bloquear senha default fora de `dev` e `test`
- adiciona validacao basica das propriedades de seguranca

## Alteracoes aplicadas
- `application.properties`: `spring.jpa.hibernate.ddl-auto=validate`
- `application-test.properties`: perfil de teste com configuracao segura para execucao automatizada
- `application-dev.properties`: permite senha default apenas em desenvolvimento
- `AppSecurityProperties`: validacao e flag `allowDefaultPassword`
- `SecurityConfig`: falha o boot quando a senha default e usada fora de ambientes permitidos

## Validacao
- `mvn -q -DskipTests compile`
- `mvn -q clean test`