### PR TITLE
security: promover reducao de exposicao de entidades

### DIFF
--- a/src/main/java/com/backup_manager/application/controller/BackupController.java
+++ b/src/main/java/com/backup_manager/application/controller/BackupController.java
@@ -3,6 +3,7 @@ package com.backup_manager.application.controller;
 import com.backup_manager.application.dto.BackupRequest;
 import com.backup_manager.application.dto.BackupResponse;
 import com.backup_manager.application.dto.BackupStatsResponse;
+import com.backup_manager.application.dto.BackupTaskSummaryResponse;
 import com.backup_manager.application.progress.ProgressEmitter;
 import com.backup_manager.application.service.BackupHistoryService;
 import com.backup_manager.application.service.BackupService;
@@ -25,8 +26,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
-
 @RestController
 @RequestMapping("/api/backup")
 public class BackupController {
@@ -267,7 +266,7 @@ public class BackupController {
     public ResponseEntity<?> getTaskStatus(@PathVariable Long taskId) {
         Optional<BackupTask> task = backupRepository.findById(taskId);
         if (task.isPresent()) {
-            return ResponseEntity.ok(task.get());
+            return ResponseEntity.ok(BackupTaskSummaryResponse.fromTask(task.get()));
         } else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Tarefa nao encontrada");
         }
@@ -275,10 +274,11 @@ public class BackupController {
 
     @GetMapping("/active")
     public ResponseEntity<?> getActiveTasks() {
-        List<BackupTask> allTasks = backupRepository.findAll();
-        List<BackupTask> activeTasks = allTasks.stream()
-                .filter(t -> t.getStatus() == Status.EM_ANDAMENTO || t.getStatus() == Status.PAUSADO)
-                .collect(Collectors.toList());
+        // Busca apenas os status operacionais necessarios para evitar filtrar tudo em memoria.
+        List<BackupTaskSummaryResponse> activeTasks = backupRepository.findByStatusIn(List.of(Status.EM_ANDAMENTO, Status.PAUSADO))
+                .stream()
+                .map(BackupTaskSummaryResponse::fromTask)
+                .toList();
 
         return ResponseEntity.ok(activeTasks);
     }

--- a/src/main/java/com/backup_manager/application/controller/RestoreController.java
+++ b/src/main/java/com/backup_manager/application/controller/RestoreController.java
@@ -1,6 +1,7 @@
 package com.backup_manager.application.controller;
 
 import com.backup_manager.application.dto.FileTreeDTO;
+import com.backup_manager.application.dto.RestoreTaskResponse;
 import com.backup_manager.application.dto.RestoreRequest;
 import com.backup_manager.application.dto.SelectiveRestoreRequest;
 import com.backup_manager.application.service.RestoreService;
@@ -155,7 +156,7 @@ public class RestoreController {
             Optional<RestoreTask> task = restoreRepository.findById(taskId);
 
             if (task.isPresent()) {
-                return ResponseEntity.ok(task.get());
+                return ResponseEntity.ok(RestoreTaskResponse.fromTask(task.get()));
             } else {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(Map.of("error", "Tarefa de restauracao nao encontrada"));
@@ -181,7 +182,8 @@ public class RestoreController {
             }
 
             Pageable pageable = PageRequest.of(page, size, Sort.by(sortDir, sortBy));
-            Page<RestoreTask> history = restoreRepository.findAllOrderByStartedAtDesc(pageable);
+            Page<RestoreTaskResponse> history = restoreRepository.findAllOrderByStartedAtDesc(pageable)
+                    .map(RestoreTaskResponse::fromTask);
 
             return ResponseEntity.ok(history);
 
@@ -202,7 +204,10 @@ public class RestoreController {
             }
 
             Pageable pageable = PageRequest.of(0, limit);
-            List<RestoreTask> recent = restoreRepository.findTopNByOrderByStartedAtDesc(pageable);
+            List<RestoreTaskResponse> recent = restoreRepository.findTopNByOrderByStartedAtDesc(pageable)
+                    .stream()
+                    .map(RestoreTaskResponse::fromTask)
+                    .toList();
 
             return ResponseEntity.ok(recent);
 
@@ -216,7 +221,10 @@ public class RestoreController {
     @GetMapping("/backup/{id}/restore/history")
     public ResponseEntity<?> getBackupRestoreHistory(@PathVariable Long id) {
         try {
-            List<RestoreTask> history = restoreRepository.findByBackupId(id);
+            List<RestoreTaskResponse> history = restoreRepository.findByBackupId(id)
+                    .stream()
+                    .map(RestoreTaskResponse::fromTask)
+                    .toList();
             return ResponseEntity.ok(history);
 
         } catch (Exception e) {

--- a/src/main/java/com/backup_manager/application/dto/BackupTaskSummaryResponse.java
+++ b/src/main/java/com/backup_manager/application/dto/BackupTaskSummaryResponse.java
@@ -1,0 +1,57 @@
+package com.backup_manager.application.dto;
+
+import com.backup_manager.domain.model.BackupTask;
+import com.backup_manager.domain.model.Status;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class BackupTaskSummaryResponse {
+
+    private final Long id;
+    private final String sourcePath;
+    private final String destinationPath;
+    private final Status status;
+    private final String errorMessage;
+    private final Long fileCount;
+    private final BigDecimal totalSizeMB;
+    private final LocalDateTime startedAt;
+    private final LocalDateTime finishedAt;
+    private final LocalDateTime pausedAt;
+    private final String duration;
+
+    public static BackupTaskSummaryResponse fromTask(BackupTask task) {
+        String duration = "";
+        if (task.getStartedAt() != null && task.getFinishedAt() != null) {
+            long seconds = Duration.between(task.getStartedAt(), task.getFinishedAt()).getSeconds();
+            duration = String.format("%02d:%02d:%02d",
+                    seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+        }
+
+        BigDecimal totalSize = Objects.requireNonNullElse(task.getTotalSizeMB(), BigDecimal.ZERO)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new BackupTaskSummaryResponse(
+                task.getId(),
+                task.getSourcePath(),
+                task.getDestinationPath(),
+                task.getStatus(),
+                task.getErrorMessage(),
+                task.getFileCount(),
+                totalSize,
+                task.getStartedAt(),
+                task.getFinishedAt(),
+                task.getPausedAt(),
+                duration
+        );
+    }
+}

--- a/src/main/java/com/backup_manager/application/dto/RestoreTaskResponse.java
+++ b/src/main/java/com/backup_manager/application/dto/RestoreTaskResponse.java
@@ -1,0 +1,62 @@
+package com.backup_manager.application.dto;
+
+import com.backup_manager.domain.model.RestoreStatus;
+import com.backup_manager.domain.model.RestoreTask;
+import com.backup_manager.domain.model.RestoreType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class RestoreTaskResponse {
+
+    private final Long id;
+    private final Long backupTaskId;
+    private final String targetPath;
+    private final RestoreType restoreType;
+    private final RestoreStatus status;
+    private final Long fileCount;
+    private final BigDecimal totalSizeMB;
+    private final Long restoredFiles;
+    private final LocalDateTime startedAt;
+    private final LocalDateTime finishedAt;
+    private final String errorMessage;
+    private final boolean selectiveRestore;
+    private final String duration;
+
+    public static RestoreTaskResponse fromTask(RestoreTask task) {
+        String duration = "";
+        if (task.getStartedAt() != null && task.getFinishedAt() != null) {
+            long seconds = Duration.between(task.getStartedAt(), task.getFinishedAt()).getSeconds();
+            duration = String.format("%02d:%02d:%02d",
+                    seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+        }
+
+        BigDecimal totalSize = Objects.requireNonNullElse(task.getTotalSizeMB(), BigDecimal.ZERO)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new RestoreTaskResponse(
+                task.getId(),
+                task.getSourceBackup() != null ? task.getSourceBackup().getId() : null,
+                task.getTargetPath(),
+                task.getRestoreType(),
+                task.getStatus(),
+                task.getFileCount(),
+                totalSize,
+                task.getRestoredFiles(),
+                task.getStartedAt(),
+                task.getFinishedAt(),
+                task.getErrorMessage(),
+                task.getRestoreType() == RestoreType.SELECTIVE,
+                duration
+        );
+    }
+}


### PR DESCRIPTION
## Resumo
- promove para master o endurecimento de respostas operacionais com DTOs de backup e restauracao
- reduz a serializacao direta de entidades JPA em endpoints expostos
- preserva a validacao ja executada em develop antes da promocao final

## Alteracoes aplicadas
- `BackupController`: respostas de status e tarefas ativas passam a usar DTO operacional
- `RestoreController`: respostas de status, historico e recentes passam a usar DTO operacional
- DTOs dedicados para backup e restauracao com campos operacionais e duracao formatada

## Validacao
- checks do PR para develop aprovados
- workflows de push na develop aprovados apos o merge