### PR TITLE
security: promover allowlist de paths operacionais

### DIFF
--- a/src/main/java/com/backup_manager/application/service/BackupService.java
+++ b/src/main/java/com/backup_manager/application/service/BackupService.java
@@ -49,6 +49,7 @@ public class BackupService {
     private final BackupTaskManager taskManager;
     private final FileStorageOperations storageOps;
     private final ApplicationEventPublisher eventPublisher;
+    private final PathSecurityService pathSecurityService;
     private final BackupService self;
 
     @Value("${backup.excluded-folders:AppData,Temp,node_modules}")
@@ -64,6 +65,7 @@ public class BackupService {
             BackupTaskManager taskManager,
             FileStorageOperations storageOps,
             ApplicationEventPublisher eventPublisher,
+            PathSecurityService pathSecurityService,
             @Lazy BackupService self
     ) {
         this.backupManager = backupManager;
@@ -73,6 +75,7 @@ public class BackupService {
         this.taskManager = taskManager;
         this.storageOps = storageOps;
         this.eventPublisher = eventPublisher;
+        this.pathSecurityService = pathSecurityService;
         this.self = self;
     }
 
@@ -324,28 +327,7 @@ public class BackupService {
     }
 
     public void validateSafePath(String path) {
-        if (path == null || path.isBlank()) {
-            return;
-        }
-
-        Path normalizedPath = Paths.get(path).toAbsolutePath().normalize();
-        String normalized = normalizedPath.toString().toLowerCase();
-
-        String rootDir = System.getenv("SystemRoot");
-        String windowsDir = rootDir != null ? rootDir.toLowerCase() : "c:\\windows";
-
-        boolean isForbidden = normalized.startsWith(windowsDir)
-                || normalized.contains("system32")
-                || normalized.contains("syswow64")
-                || normalized.contains("program files")
-                || normalized.matches("^[a-z]:\\\\$");
-
-        if (isForbidden) {
-            logger.error("BLOQUEIO DE SEGURANCA: Caminho restrito detectado: {}", path);
-            throw new SecurityException(
-                    "Acesso negado: O caminho '" + path + "' e uma area protegida do sistema operacional."
-            );
-        }
+        pathSecurityService.validateManagedPath(path, "backup");
     }
 
     private void handlePause(BackupTask task, Long taskId, int processed, int total) {

--- a/src/main/java/com/backup_manager/application/service/PathSecurityService.java
+++ b/src/main/java/com/backup_manager/application/service/PathSecurityService.java
@@ -1,0 +1,94 @@
+package com.backup_manager.application.service;
+
+import com.backup_manager.infrastructure.config.AppSecurityProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class PathSecurityService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PathSecurityService.class);
+
+    private final AppSecurityProperties securityProperties;
+
+    public PathSecurityService(AppSecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    public Path validateManagedPath(String rawPath, String operationName) {
+        if (rawPath == null || rawPath.isBlank()) {
+            throw new IllegalArgumentException("Caminho nao pode estar vazio para " + operationName);
+        }
+
+        Path normalizedPath = Paths.get(rawPath).toAbsolutePath().normalize();
+        ensureNotPathTraversal(rawPath, operationName);
+        ensureNotProtectedSystemPath(normalizedPath, operationName);
+        ensureWithinAllowedRoots(normalizedPath, operationName);
+        return normalizedPath;
+    }
+
+    public Path validateWritableManagedPath(String rawPath, String operationName) {
+        Path normalizedPath = validateManagedPath(rawPath, operationName);
+        Path parent = normalizedPath.getParent();
+
+        if (parent != null && Files.exists(parent) && !Files.isWritable(parent)) {
+            throw new SecurityException("Sem permissao de escrita no destino informado para " + operationName + ".");
+        }
+
+        return normalizedPath;
+    }
+
+    private void ensureNotPathTraversal(String rawPath, String operationName) {
+        if (rawPath.contains("..")) {
+            logger.warn("Path traversal bloqueado em {}: {}", operationName, rawPath);
+            throw new SecurityException("Path traversal detectado na operacao de " + operationName + ".");
+        }
+    }
+
+    private void ensureNotProtectedSystemPath(Path normalizedPath, String operationName) {
+        String normalized = normalizedPath.toString().toLowerCase();
+        String rootDir = System.getenv("SystemRoot");
+        String windowsDir = rootDir != null ? rootDir.toLowerCase() : "c:\\windows";
+
+        boolean isForbidden = normalized.startsWith(windowsDir)
+                || normalized.contains("system32")
+                || normalized.contains("syswow64")
+                || normalized.contains("program files")
+                || normalized.matches("^[a-z]:\\\\$");
+
+        if (isForbidden) {
+            logger.warn("Caminho protegido bloqueado em {}: {}", operationName, normalizedPath);
+            throw new SecurityException("O caminho informado pertence a uma area protegida do sistema.");
+        }
+    }
+
+    private void ensureWithinAllowedRoots(Path normalizedPath, String operationName) {
+        List<Path> allowedRoots = getAllowedRoots();
+        boolean isAllowed = allowedRoots.stream().anyMatch(normalizedPath::startsWith);
+
+        if (!isAllowed) {
+            logger.warn("Caminho fora da allowlist bloqueado em {}: {}", operationName, normalizedPath);
+            throw new SecurityException("O caminho informado nao pertence a uma raiz permitida.");
+        }
+    }
+
+    private List<Path> getAllowedRoots() {
+        if (securityProperties.getAllowedPathRoots() == null || securityProperties.getAllowedPathRoots().isEmpty()) {
+            return List.of(Paths.get(System.getProperty("user.home")).toAbsolutePath().normalize());
+        }
+
+        return securityProperties.getAllowedPathRoots().stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(path -> !path.isEmpty())
+                .map(path -> Paths.get(path).toAbsolutePath().normalize())
+                .toList();
+    }
+}

--- a/src/main/java/com/backup_manager/application/service/RestoreService.java
+++ b/src/main/java/com/backup_manager/application/service/RestoreService.java
@@ -47,6 +47,7 @@ public class RestoreService {
     private final FileRestoreOperations restoreOps;
     private final ApplicationEventPublisher eventPublisher;
     private final ObjectMapper objectMapper;
+    private final PathSecurityService pathSecurityService;
     private final RestoreService self;
 
     public RestoreService(BackupRepository backupRepository,
@@ -54,12 +55,14 @@ public class RestoreService {
                           RestoreTaskManager taskManager,
                           FileRestoreOperations restoreOps,
                           ApplicationEventPublisher eventPublisher,
+                          PathSecurityService pathSecurityService,
                           @Lazy RestoreService self) {
         this.backupRepository = backupRepository;
         this.restoreRepository = restoreRepository;
         this.taskManager = taskManager;
         this.restoreOps = restoreOps;
         this.eventPublisher = eventPublisher;
+        this.pathSecurityService = pathSecurityService;
         this.objectMapper = new ObjectMapper();
         this.self = self;
     }
@@ -174,6 +177,8 @@ public class RestoreService {
                 backupId, request.getTargetPath());
 
         BackupTask backup = validateBackup(backupId);
+        // Reaproveita a allowlist compartilhada para impedir restauracoes fora das raizes aprovadas.
+        pathSecurityService.validateWritableManagedPath(request.getTargetPath(), "restauracao");
         validateRestorePath(request.getTargetPath());
 
         RestoreTask task = createRestoreTask(backup, request.getTargetPath(),
@@ -195,6 +200,8 @@ public class RestoreService {
         BackupTask backup = validateBackup(backupId);
         Path backupRoot = Paths.get(backup.getDestinationPath());
 
+        // Reaproveita a allowlist compartilhada para impedir restauracoes fora das raizes aprovadas.
+        pathSecurityService.validateWritableManagedPath(request.getTargetPath(), "restauracao");
         validateRestorePath(request.getTargetPath());
         validateSelectedFiles(request.getSelectedFiles(), backupRoot);
 

--- a/src/main/java/com/backup_manager/infrastructure/config/AppSecurityProperties.java
+++ b/src/main/java/com/backup_manager/infrastructure/config/AppSecurityProperties.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,4 +27,6 @@ public class AppSecurityProperties {
     private String role = "ADMIN";
 
     private boolean allowDefaultPassword = false;
+
+    private List<String> allowedPathRoots = new ArrayList<>();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,4 @@ app.security.username=${APP_SECURITY_USERNAME:admin}
 app.security.password=${APP_SECURITY_PASSWORD:change-me-now}
 app.security.role=${APP_SECURITY_ROLE:ADMIN}
 app.security.allow-default-password=${APP_SECURITY_ALLOW_DEFAULT_PASSWORD:false}
+app.security.allowed-path-roots=${APP_SECURITY_ALLOWED_PATH_ROOTS:${user.home}}

--- a/src/test/java/com/backup_manager/application/service/PathSecurityServiceTests.java
+++ b/src/test/java/com/backup_manager/application/service/PathSecurityServiceTests.java
@@ -1,0 +1,58 @@
+package com.backup_manager.application.service;
+
+import com.backup_manager.infrastructure.config.AppSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PathSecurityServiceTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldAllowPathInsideConfiguredRoot() {
+        PathSecurityService service = createService(List.of(tempDir.toString()));
+        Path allowedFile = tempDir.resolve("documents").resolve("backup.zip");
+
+        assertDoesNotThrow(() -> service.validateManagedPath(allowedFile.toString(), "backup"));
+    }
+
+    @Test
+    void shouldBlockPathOutsideConfiguredRoot() {
+        PathSecurityService service = createService(List.of(tempDir.toString()));
+        Path outsidePath = tempDir.getParent().resolve("fora-da-allowlist");
+
+        assertThrows(SecurityException.class,
+                () -> service.validateManagedPath(outsidePath.toString(), "backup"));
+    }
+
+    @Test
+    void shouldBlockPathTraversalAttempt() {
+        PathSecurityService service = createService(List.of(tempDir.toString()));
+        String traversalPath = tempDir.resolve("docs").resolve("..").resolve("segredo").toString();
+
+        assertThrows(SecurityException.class,
+                () -> service.validateManagedPath(traversalPath, "backup"));
+    }
+
+    @Test
+    void shouldFallbackToUserHomeWhenAllowlistIsEmpty() {
+        PathSecurityService service = createService(List.of());
+        Path homePath = Paths.get(System.getProperty("user.home")).resolve("backup-test");
+
+        assertDoesNotThrow(() -> service.validateManagedPath(homePath.toString(), "backup"));
+    }
+
+    private PathSecurityService createService(List<String> allowedRoots) {
+        AppSecurityProperties properties = new AppSecurityProperties();
+        properties.setAllowedPathRoots(allowedRoots);
+        return new PathSecurityService(properties);
+    }
+}


### PR DESCRIPTION
## Resumo
- promove para master a allowlist de paths para backup e restauracao
- centraliza a validacao de filesystem em um servico compartilhado
- inclui cobertura automatizada para cenarios permitidos e bloqueados

## Alteracoes aplicadas
- `PathSecurityService`: valida traversal, areas protegidas e raizes permitidas
- `AppSecurityProperties`: adiciona configuracao de `allowedPathRoots`
- `BackupService` e `RestoreService`: passam a usar a allowlist compartilhada
- `PathSecurityServiceTests`: cobre allowlist configurada, traversal e fallback

## Validacao
- checks do PR para develop aprovados
- workflows de push na develop aprovados apos o merge